### PR TITLE
Add support for multiple tags on the same commit.

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -87,8 +87,7 @@ function build_prompt {
             local number_of_untracked_files=$(\grep -c "^??" <<< "${git_status}")
             if [[ $number_of_untracked_files -gt 0 ]]; then local has_untracked_files=true; fi
         
-            local tag_at_current_commit=$(git describe --exact-match --tags $current_commit_hash 2> /dev/null)
-            if [[ -n $tag_at_current_commit ]]; then local is_on_a_tag=true; fi
+            local tags_at_current_commit=$(git tag --points-at $current_commit_hash 2> /dev/null)
         
             if [[ $has_upstream == true ]]; then
                 local commits_diff="$(git log --pretty=oneline --topo-order --left-right ${current_commit_hash}...${upstream} 2> /dev/null)"
@@ -156,8 +155,7 @@ function build_prompt {
         ${has_deletions_cached:-false} \
         ${has_untracked_files:-false} \
         ${ready_to_commit:-false} \
-        ${tag_at_current_commit:-""} \
-        ${is_on_a_tag:-false} \
+        "${tags_at_current_commit:-""}" \
         ${has_upstream:-false} \
         ${commits_ahead:-false} \
         ${commits_behind:-false} \

--- a/prompt.sh
+++ b/prompt.sh
@@ -63,8 +63,7 @@ if [ -n "${BASH_VERSION}" ]; then
         local has_deletions_cached=${1}; shift 1;
         local has_untracked_files=${1}; shift 1;
         local ready_to_commit=${1}; shift 1;
-        local tag_at_current_commit=${1}; shift 1;
-        local is_on_a_tag=${1}; shift 1;
+        local tags_at_current_commit=${1}; shift 1;
         local has_upstream=${1}; shift 1;
         local commits_ahead=${1}; shift 1;
         local commits_behind=${1}; shift 1;
@@ -194,7 +193,9 @@ if [ -n "${BASH_VERSION}" ]; then
                     prompt+=$(enrich_append true "(${current_branch} ${type_of_upstream} ${upstream//\/$current_branch/})" "${black_on_red}")
                 fi
             fi
-            prompt+=$(enrich_append ${is_on_a_tag} "${omg_is_on_a_tag_symbol} ${tag_at_current_commit}" "${black_on_red}")
+            for tag in ${tags_at_current_commit}; do
+                prompt+=$(enrich_append true "${omg_is_on_a_tag_symbol} ${tag}" "${black_on_red}")
+            done
             prompt+="${reset}${red}${omg_arrow_symbol}${reset}\n"
             prompt+="$(eval_prompt_callback_if_present)"
             prompt+="${omg_second_line}"


### PR DESCRIPTION
This change allows oh-my-git to show multiple tags when they all apply to the same commit.  In certain workflows this is very useful, since it can be common to have the same commit tagged for multiple releases.