### PR TITLE
Add an indicator for rename operations.

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -82,6 +82,7 @@ function build_prompt {
             if [[ $git_status =~ ($'\n'|^)A ]]; then local has_adds=true; fi
             if [[ $git_status =~ ($'\n'|^).D ]]; then local has_deletions=true; fi
             if [[ $git_status =~ ($'\n'|^)D ]]; then local has_deletions_cached=true; fi
+            if [[ $git_status =~ ($'\n'|^)R ]]; then local has_renames=true; fi
             if [[ $git_status =~ ($'\n'|^)[MAD] && ! $git_status =~ ($'\n'|^).[MAD\?] ]]; then local ready_to_commit=true; fi
 
             local number_of_untracked_files=$(\grep -c "^??" <<< "${git_status}")
@@ -153,6 +154,7 @@ function build_prompt {
         ${has_adds:-false} \
         ${has_deletions:-false} \
         ${has_deletions_cached:-false} \
+        ${has_renames:-false} \
         ${has_untracked_files:-false} \
         ${ready_to_commit:-false} \
         "${tags_at_current_commit:-""}" \

--- a/prompt.sh
+++ b/prompt.sh
@@ -14,6 +14,7 @@ if [ -n "${BASH_VERSION}" ]; then
     : ${omg_has_adds_symbol:=''}
     : ${omg_has_deletions_symbol:=''}
     : ${omg_has_cached_deletions_symbol:=''}
+    : ${omg_has_renames_symbol:=''}                # 
     : ${omg_has_modifications_symbol:=''}
     : ${omg_has_cached_modifications_symbol:=''}
     : ${omg_ready_to_commit_symbol:=''}            #   →
@@ -62,6 +63,7 @@ if [ -n "${BASH_VERSION}" ]; then
         local has_adds=${1}; shift 1;
         local has_deletions=${1}; shift 1;
         local has_deletions_cached=${1}; shift 1;
+        local has_renames=${1}; shift 1;
         local has_untracked_files=${1}; shift 1;
         local ready_to_commit=${1}; shift 1;
         local tags_at_current_commit=${1}; shift 1;
@@ -144,8 +146,11 @@ if [ -n "${BASH_VERSION}" ]; then
             if [[ ${omg_condensed} == true && ${has_deletions_cached} == true ]]; then
                 has_modifications_cached=true
             fi
+            if [[ ${omg_condensed} == true && ${has_renames} == true ]]; then
+                has_modifications_cached=true
+            fi
             if [[ ${omg_condensed} == false ]]; then
-                prompt+=$(enrich_append $has_adds $omg_has_adds_symbol "${black_on_white}")
+                prompt+=$(enrich_append $has_adds $omg_has_adds_symbol $omg_has_renames_symbol "${black_on_white}")
             fi
             prompt+=$(enrich_append $has_modifications_cached $omg_has_cached_modifications_symbol "${black_on_white}")
             if [[ ${omg_condensed} == false ]]; then


### PR DESCRIPTION
Without this a staged rename operation does not show up in any of the status indicators.